### PR TITLE
Make RxJS a peerDependency & enable Node 20

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [16.x, 18.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v1
               with:
-                  node-version: 18
+                  node-version: 20
             - name: Update Git
               run: git fetch --all
             - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
             "license": "GPL-3.0",
             "dependencies": {
                 "color-convert": "2.0.1",
-                "protobufjs": "7.2.3",
-                "rxjs": "7.8.0"
+                "protobufjs": "7.2.3"
             },
             "devDependencies": {
                 "@commitlint/cli": "17.5.1",
@@ -38,6 +37,9 @@
                 "ts-node-dev": "2.0.0",
                 "ts-proto": "1.147.1",
                 "typescript": "5.0.4"
+            },
+            "peerDependencies": {
+                "rxjs": "^7.8.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -11307,9 +11309,10 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -12658,7 +12661,8 @@
         "node_modules/tslib": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "license": "GPL-3.0",
     "dependencies": {
         "color-convert": "2.0.1",
-        "protobufjs": "7.2.3",
-        "rxjs": "7.8.0"
+        "protobufjs": "7.2.3"
+    },
+    "peerDependencies": {
+        "rxjs": "^7.8.1"
     },
     "devDependencies": {
         "@commitlint/cli": "17.5.1",


### PR DESCRIPTION
Regarding the RxJS change, the current version is causing problems when consuming applications are using a different version of RxJS where the types might have slightly changed. 

And Node 20 is simply the next LTS version of Node. 