### PR TITLE
Draft implementation of NoiseClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.3.1",
             "license": "GPL-3.0",
             "dependencies": {
+                "@richardhopton/noise-c.wasm": "0.5.0",
                 "color-convert": "2.0.1",
                 "protobufjs": "7.2.3"
             },
@@ -42,13 +43,22 @@
                 "rxjs": "^7.8.1"
             }
         },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-            "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.1.0",
+                "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
             },
             "engines": {
@@ -56,46 +66,46 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.21.4",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-            "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+            "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.18.6"
+                "@babel/highlight": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
-            "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
+            "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
-            "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
+            "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
             "dev": true,
             "dependencies": {
-                "@ampproject/remapping": "^2.1.0",
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.13",
-                "@babel/helper-compilation-targets": "^7.18.9",
-                "@babel/helper-module-transforms": "^7.18.9",
-                "@babel/helpers": "^7.18.9",
-                "@babel/parser": "^7.18.13",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.18.13",
-                "@babel/types": "^7.18.13",
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.22.5",
+                "@babel/generator": "^7.22.5",
+                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/helper-module-transforms": "^7.22.5",
+                "@babel/helpers": "^7.22.5",
+                "@babel/parser": "^7.22.5",
+                "@babel/template": "^7.22.5",
+                "@babel/traverse": "^7.22.5",
+                "@babel/types": "^7.22.5",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.1",
+                "json5": "^2.2.2",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -116,42 +126,30 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
-            "integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
+            "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.13",
+                "@babel/types": "^7.22.5",
                 "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-            "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
+            "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.18.8",
-                "@babel/helper-validator-option": "^7.18.6",
-                "browserslist": "^4.20.2",
+                "@babel/compat-data": "^7.22.5",
+                "@babel/helper-validator-option": "^7.22.5",
+                "browserslist": "^4.21.3",
+                "lru-cache": "^5.1.1",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -171,151 +169,151 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-            "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.18.6",
-                "@babel/types": "^7.18.9"
+                "@babel/template": "^7.22.5",
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-            "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-            "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-            "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
+            "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "@babel/template": "^7.18.6",
-                "@babel/traverse": "^7.18.9",
-                "@babel/types": "^7.18.9"
+                "@babel/helper-environment-visitor": "^7.22.5",
+                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/helper-simple-access": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/template": "^7.22.5",
+                "@babel/traverse": "^7.22.5",
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-            "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-            "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-            "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
+            "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-            "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-            "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-            "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
+            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-            "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
+            "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.18.6",
-                "@babel/traverse": "^7.18.9",
-                "@babel/types": "^7.18.9"
+                "@babel/template": "^7.22.5",
+                "@babel/traverse": "^7.22.5",
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+            "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.18.6",
+                "@babel/helper-validator-identifier": "^7.22.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -395,9 +393,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-            "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
+            "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -554,12 +552,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
-            "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
+            "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.18.6"
+                "@babel/helper-plugin-utils": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -569,33 +567,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/code-frame": "^7.22.5",
+                "@babel/parser": "^7.22.5",
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
-            "integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
+            "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.13",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.18.9",
-                "@babel/helper-hoist-variables": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.18.13",
-                "@babel/types": "^7.18.13",
+                "@babel/code-frame": "^7.22.5",
+                "@babel/generator": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.5",
+                "@babel/helper-function-name": "^7.22.5",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.5",
+                "@babel/parser": "^7.22.5",
+                "@babel/types": "^7.22.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -613,13 +611,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.18.13",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
-            "integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+            "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.18.10",
-                "@babel/helper-validator-identifier": "^7.18.6",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.5",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -731,27 +729,27 @@
             }
         },
         "node_modules/@commitlint/is-ignored": {
-            "version": "17.6.3",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.3.tgz",
-            "integrity": "sha512-LQbNdnPbxrpbcrVKR5yf51SvquqktpyZJwqXx3lUMF6+nT9PHB8xn3wLy8pi2EQv5Zwba484JnUwDE1ygVYNQA==",
+            "version": "17.6.6",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+            "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
             "dev": true,
             "dependencies": {
                 "@commitlint/types": "^17.4.4",
-                "semver": "7.5.0"
+                "semver": "7.5.2"
             },
             "engines": {
                 "node": ">=v14"
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "17.6.3",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.3.tgz",
-            "integrity": "sha512-fBlXwt6SHJFgm3Tz+luuo3DkydAx9HNC5y4eBqcKuDuMVqHd2ugMNr+bQtx6riv9mXFiPoKp7nE4Xn/ls3iVDA==",
+            "version": "17.6.6",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+            "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
             "dev": true,
             "dependencies": {
-                "@commitlint/is-ignored": "^17.6.3",
-                "@commitlint/parse": "^17.4.4",
-                "@commitlint/rules": "^17.6.1",
+                "@commitlint/is-ignored": "^17.6.6",
+                "@commitlint/parse": "^17.6.5",
+                "@commitlint/rules": "^17.6.5",
                 "@commitlint/types": "^17.4.4"
             },
             "engines": {
@@ -793,9 +791,9 @@
             }
         },
         "node_modules/@commitlint/parse": {
-            "version": "17.4.4",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.4.tgz",
-            "integrity": "sha512-EKzz4f49d3/OU0Fplog7nwz/lAfXMaDxtriidyGF9PtR+SRbgv4FhsfF310tKxs6EPj8Y+aWWuX3beN5s+yqGg==",
+            "version": "17.6.5",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.6.5.tgz",
+            "integrity": "sha512-0zle3bcn1Hevw5Jqpz/FzEWNo2KIzUbc1XyGg6WrWEoa6GH3A1pbqNF6MvE6rjuy6OY23c8stWnb4ETRZyN+Yw==",
             "dev": true,
             "dependencies": {
                 "@commitlint/types": "^17.4.4",
@@ -822,20 +820,6 @@
                 "node": ">=v14"
             }
         },
-        "node_modules/@commitlint/read/node_modules/fs-extra": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
         "node_modules/@commitlint/resolve-extends": {
             "version": "17.4.4",
             "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
@@ -854,9 +838,9 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "17.6.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
-            "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
+            "version": "17.6.5",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.5.tgz",
+            "integrity": "sha512-uTB3zSmnPyW2qQQH+Dbq2rekjlWRtyrjDo4aLFe63uteandgkI+cc0NhhbBAzcXShzVk0qqp8SlkQMu0mgHg/A==",
             "dev": true,
             "dependencies": {
                 "@commitlint/ensure": "^17.4.4",
@@ -940,23 +924,23 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -1003,9 +987,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -1414,13 +1398,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-            "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.0",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -1445,20 +1430,26 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "dev": true
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1496,28 +1487,25 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
-            "integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
             "dev": true,
-            "dependencies": {
-                "@octokit/types": "^7.0.0"
-            },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
-            "integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
             "dev": true,
             "dependencies": {
                 "@octokit/auth-token": "^3.0.0",
                 "@octokit/graphql": "^5.0.0",
                 "@octokit/request": "^6.0.0",
                 "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^7.0.0",
+                "@octokit/types": "^9.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             },
@@ -1526,12 +1514,12 @@
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-            "integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^7.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             },
@@ -1540,13 +1528,13 @@
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
-            "integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
             "dev": true,
             "dependencies": {
                 "@octokit/request": "^6.0.0",
-                "@octokit/types": "^7.0.0",
+                "@octokit/types": "^9.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
@@ -1554,18 +1542,19 @@
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "13.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.4.0.tgz",
-            "integrity": "sha512-2mVzW0X1+HDO3jF80/+QFZNzJiTefELKbhMu6yaBYbp/1gSMkVDm4rT472gJljTokWUlXaaE63m7WrWENhMDLw==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
             "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.1.0.tgz",
-            "integrity": "sha512-2O5K5fpajYG5g62wjzHR7/cWYaCA88CextAW3vFP+yoIHD0KEdlVMHfM5/i5LyV+JMmqiYW7w5qfg46FR+McNw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^7.1.1"
+                "@octokit/tsconfig": "^1.0.2",
+                "@octokit/types": "^9.2.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -1574,23 +1563,14 @@
                 "@octokit/core": ">=4"
             }
         },
-        "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-            "dev": true,
-            "peerDependencies": {
-                "@octokit/core": ">=3"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz",
-            "integrity": "sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==",
+        "node_modules/@octokit/plugin-retry": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
+            "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^7.0.0",
-                "deprecation": "^2.3.1"
+                "@octokit/types": "^9.0.0",
+                "bottleneck": "^2.15.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -1599,15 +1579,31 @@
                 "@octokit/core": ">=3"
             }
         },
+        "node_modules/@octokit/plugin-throttling": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+            "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": "^4.0.0"
+            }
+        },
         "node_modules/@octokit/request": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
-            "integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
             "dev": true,
             "dependencies": {
                 "@octokit/endpoint": "^7.0.0",
                 "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^7.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
                 "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
@@ -1617,12 +1613,12 @@
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
-            "integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^7.0.0",
+                "@octokit/types": "^9.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             },
@@ -1630,28 +1626,19 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/@octokit/rest": {
-            "version": "19.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
-            "integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
-            "dev": true,
-            "dependencies": {
-                "@octokit/core": "^4.0.0",
-                "@octokit/plugin-paginate-rest": "^4.0.0",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
+        "node_modules/@octokit/tsconfig": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+            "dev": true
         },
         "node_modules/@octokit/types": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.1.tgz",
-            "integrity": "sha512-Dx6cNTORyVaKY0Yeb9MbHksk79L8GXsihbG6PtWqTpkyA2TY1qBWE26EQXVG3dHwY9Femdd/WEeRUEiD0+H3TQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
             "dev": true,
             "dependencies": {
-                "@octokit/openapi-types": "^13.4.0"
+                "@octokit/openapi-types": "^18.0.0"
             }
         },
         "node_modules/@pnpm/config.env-replace": {
@@ -1675,10 +1662,16 @@
                 "node": ">=12.22.0"
             }
         },
+        "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
         "node_modules/@pnpm/npm-conf": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.1.1.tgz",
-            "integrity": "sha512-yfRcuupmxxeDOSxvw4g+wFCrGiPD0L32f5WMzqMXp7Rl93EOCdFiDcaSNnZ10Up9GdNqkj70UTa8hfhPFphaZA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
             "dev": true,
             "dependencies": {
                 "@pnpm/config.env-replace": "^1.1.0",
@@ -1743,6 +1736,11 @@
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
+        "node_modules/@richardhopton/noise-c.wasm": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@richardhopton/noise-c.wasm/-/noise-c.wasm-0.5.0.tgz",
+            "integrity": "sha512-ueWk5iy/0fOf4cNHXfZvwq1w1mIsgi/2ZMO+3bjiV+KupmWdgyTljWNIh7wjjwML7r1BtVkzjws9wHwVlp4JPA=="
+        },
         "node_modules/@semantic-release/changelog": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -1759,20 +1757,6 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=18.0.0"
-            }
-        },
-        "node_modules/@semantic-release/changelog/node_modules/fs-extra": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-            "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/@semantic-release/commit-analyzer": {
@@ -1828,26 +1812,27 @@
             }
         },
         "node_modules/@semantic-release/github": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.5.tgz",
-            "integrity": "sha512-9pGxRM3gv1hgoZ/muyd4pWnykdIUVfCiev6MXE9lOyGQof4FQy95GFE26nDcifs9ZG7bBzV8ue87bo/y1zVf0g==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
+            "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
             "dev": true,
             "dependencies": {
-                "@octokit/rest": "^19.0.0",
-                "@semantic-release/error": "^2.2.0",
+                "@octokit/core": "^4.2.1",
+                "@octokit/plugin-paginate-rest": "^6.1.2",
+                "@octokit/plugin-retry": "^4.1.3",
+                "@octokit/plugin-throttling": "^5.2.3",
+                "@semantic-release/error": "^3.0.0",
                 "aggregate-error": "^3.0.0",
-                "bottleneck": "^2.18.1",
                 "debug": "^4.0.0",
                 "dir-glob": "^3.0.0",
-                "fs-extra": "^10.0.0",
+                "fs-extra": "^11.0.0",
                 "globby": "^11.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
                 "issue-parser": "^6.0.0",
                 "lodash": "^4.17.4",
                 "mime": "^3.0.0",
                 "p-filter": "^2.0.0",
-                "p-retry": "^4.0.0",
                 "url-join": "^4.0.0"
             },
             "engines": {
@@ -1857,19 +1842,13 @@
                 "semantic-release": ">=18.0.0-beta.1"
             }
         },
-        "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-            "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-            "dev": true
-        },
         "node_modules/@semantic-release/npm": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.3.tgz",
-            "integrity": "sha512-Chbv3kX4o+y+r1X6hsqBVB8NFbSVfiNlYOqMG6o9Wc8r5Y4cjxfbaMCuJ++XAtw3YXYX/NVD05cPzBi4Orjusg==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.4.tgz",
+            "integrity": "sha512-6R3timIQ7VoL2QWRkc9DG8v74RQtRp7UOe/2KbNaqwJ815qOibAv65bH3RtTEhs4axEaHoZf7HDgFs5opaZ9Jw==",
             "dev": true,
             "dependencies": {
-                "@semantic-release/error": "^3.0.0",
+                "@semantic-release/error": "^4.0.0",
                 "aggregate-error": "^4.0.1",
                 "execa": "^7.0.0",
                 "fs-extra": "^11.0.0",
@@ -1888,6 +1867,15 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
@@ -1954,20 +1942,6 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/fs-extra": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
@@ -2161,9 +2135,9 @@
             }
         },
         "node_modules/@semantic-release/npm/node_modules/type-fest": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.9.0.tgz",
-            "integrity": "sha512-hR8JP2e8UiH7SME5JZjsobBlEiatFoxpzCP+R3ZeCo7kAaG1jXQE5X/buLzogM6GJu8le9Y4OcfNuIQX0rZskA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
+            "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
             "dev": true,
             "engines": {
                 "node": ">=14.16"
@@ -2173,17 +2147,17 @@
             }
         },
         "node_modules/@semantic-release/release-notes-generator": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.1.tgz",
-            "integrity": "sha512-4deWsiY4Rg80oc9Ms11N20BIDgYkPMys4scNYQpi2Njdrtw5Z55nXKNsUN3kn6Sy/nI9dqqbp5L63TL4luI5Bw==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.3.tgz",
+            "integrity": "sha512-NU77dWKQf+QcZrv/Hcp3DPeSxglPu8hYKCipGxAPpeaneLkg6S0zfTVug4tg4mfDhZHC6RtoI7ljQDK8VoJ2Dw==",
             "dev": true,
             "dependencies": {
-                "conventional-changelog-angular": "^5.0.0",
-                "conventional-changelog-writer": "^5.0.0",
-                "conventional-commits-filter": "^2.0.0",
-                "conventional-commits-parser": "^3.2.3",
+                "conventional-changelog-angular": "^6.0.0",
+                "conventional-changelog-writer": "^6.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "conventional-commits-parser": "^4.0.0",
                 "debug": "^4.0.0",
-                "get-stream": "^6.0.0",
+                "get-stream": "^7.0.0",
                 "import-from": "^4.0.0",
                 "into-stream": "^7.0.0",
                 "lodash-es": "^4.17.21",
@@ -2194,6 +2168,49 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+            "dev": true,
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+            "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+            "dev": true,
+            "dependencies": {
+                "lodash.ismatch": "^4.4.0",
+                "modify-values": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
+            "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
+            "dev": true,
+            "dependencies": {
+                "is-text-path": "^1.0.1",
+                "JSONStream": "^1.3.5",
+                "meow": "^8.1.2",
+                "split2": "^3.2.2"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@semantic-release/release-notes-generator/node_modules/find-up": {
@@ -2207,6 +2224,18 @@
             },
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.0.tgz",
+            "integrity": "sha512-ql6FW5b8tgMYvI4UaoxG3EQN3VyZ6VeQpxNBGg5BZ4xD4u+HJeprzhMMA4OCBEGQgSR+m87pstWMpiVW64W8Fw==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2326,15 +2355,15 @@
             }
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.24.28",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
-            "integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
+            "version": "0.24.51",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+            "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
             "dev": true
         },
         "node_modules/@sinonjs/commons": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "version": "1.8.6",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+            "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
@@ -2347,15 +2376,6 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
-            }
-        },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -2377,19 +2397,19 @@
             "dev": true
         },
         "node_modules/@tsconfig/node16": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
         "node_modules/@types/babel__core": {
-            "version": "7.1.19",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
-            "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+            "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
                 "@types/babel__generator": "*",
                 "@types/babel__template": "*",
                 "@types/babel__traverse": "*"
@@ -2415,12 +2435,12 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-            "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+            "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.3.0"
+                "@babel/types": "^7.20.7"
             }
         },
         "node_modules/@types/color-convert": {
@@ -2439,9 +2459,9 @@
             "dev": true
         },
         "node_modules/@types/eslint": {
-            "version": "8.4.6",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
+            "version": "8.40.2",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
+            "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -2449,15 +2469,15 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-            "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
             "dev": true
         },
         "node_modules/@types/graceful-fs": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
-            "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -2498,9 +2518,9 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
             "dev": true
         },
         "node_modules/@types/json5": {
@@ -2539,15 +2559,9 @@
             "dev": true
         },
         "node_modules/@types/prettier": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
-            "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
-            "dev": true
-        },
-        "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+            "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
             "dev": true
         },
         "node_modules/@types/semver": {
@@ -2575,9 +2589,9 @@
             "dev": true
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.11",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-            "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+            "version": "17.0.24",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+            "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -2778,9 +2792,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -2808,15 +2822,15 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
             "dev": true,
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/aggregate-error": {
@@ -2906,9 +2920,9 @@
             "dev": true
         },
         "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -3138,9 +3152,9 @@
             "dev": true
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
             "dev": true
         },
         "node_modules/binary-extensions": {
@@ -3181,9 +3195,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-            "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+            "version": "4.21.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+            "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
             "dev": true,
             "funding": [
                 {
@@ -3193,13 +3207,17 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001370",
-                "electron-to-chromium": "^1.4.202",
-                "node-releases": "^2.0.6",
-                "update-browserslist-db": "^1.0.5"
+                "caniuse-lite": "^1.0.30001503",
+                "electron-to-chromium": "^1.4.431",
+                "node-releases": "^2.0.12",
+                "update-browserslist-db": "^1.0.11"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3284,9 +3302,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001382",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz",
-            "integrity": "sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg==",
+            "version": "1.0.30001509",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
+            "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
             "dev": true,
             "funding": [
                 {
@@ -3296,6 +3314,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ]
         },
@@ -3313,9 +3335,9 @@
             }
         },
         "node_modules/case-anything": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
-            "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+            "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
             "dev": true,
             "engines": {
                 "node": ">=12.13"
@@ -3389,15 +3411,24 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-            "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
-            "dev": true
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+            "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/cjs-module-lexer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-            "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+            "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
             "dev": true
         },
         "node_modules/clean-stack": {
@@ -3410,9 +3441,9 @@
             }
         },
         "node_modules/cli-table3": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-            "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+            "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
             "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0"
@@ -3425,14 +3456,17 @@
             }
         },
         "node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "strip-ansi": "^6.0.1",
                 "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/co": {
@@ -3530,26 +3564,37 @@
             }
         },
         "node_modules/conventional-changelog-writer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.0.tgz",
+            "integrity": "sha512-8PyWTnn7zBIt9l4hj4UusFs1TyG+9Ulu1zlOAc72L7Sdv9Hsc8E86ot7htY3HXCVhXHB/NO0pVGvZpwsyJvFfw==",
             "dev": true,
             "dependencies": {
-                "conventional-commits-filter": "^2.0.7",
-                "dateformat": "^3.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "dateformat": "^3.0.3",
                 "handlebars": "^4.7.7",
                 "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "semver": "^6.0.0",
-                "split": "^1.0.0",
-                "through2": "^4.0.0"
+                "meow": "^8.1.2",
+                "semver": "^6.3.0",
+                "split": "^1.0.1"
             },
             "bin": {
                 "conventional-changelog-writer": "cli.js"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+            "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+            "dev": true,
+            "dependencies": {
+                "lodash.ismatch": "^4.4.0",
+                "modify-values": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/conventional-changelog-writer/node_modules/semver": {
@@ -3595,13 +3640,10 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-            "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.1"
-            }
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "dev": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -3610,9 +3652,9 @@
             "dev": true
         },
         "node_modules/cosmiconfig": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-            "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
             "dev": true,
             "dependencies": {
                 "import-fresh": "^3.2.1",
@@ -3741,9 +3783,9 @@
             }
         },
         "node_modules/decamelize-keys": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-            "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+            "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
             "dev": true,
             "dependencies": {
                 "decamelize": "^1.1.0",
@@ -3751,6 +3793,9 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/decamelize-keys/node_modules/map-obj": {
@@ -3784,9 +3829,9 @@
             "dev": true
         },
         "node_modules/deepmerge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -3923,9 +3968,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.228",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
-            "integrity": "sha512-XfDHCvou7CsDMlFwb0WZ1tWmW48e7Sn7VBRyPfZsZZila9esRsJl1trO+OqDNV97GggFSt0ISbWslKXfQkG//g==",
+            "version": "1.4.447",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
+            "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -3947,9 +3992,9 @@
             "dev": true
         },
         "node_modules/env-ci": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.0.tgz",
-            "integrity": "sha512-ZCEas2sDVFR3gpumwwzSU4OJZwWJ46yqJH3TqH3vSxEBzeAlC0uCJLGAnZC0vX1TIXzHzjcwpKmUn2xw5mC/qA==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.1.tgz",
+            "integrity": "sha512-Im2yEWeF4b2RAMAaWvGioXk6m0UNaIjD8hj28j2ij5ldnIFrDQT0+pzDvpbRkcjurhXhf/AsBKv8P2rtmGi9Aw==",
             "dev": true,
             "dependencies": {
                 "execa": "^7.0.0",
@@ -4289,9 +4334,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-            "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+            "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
             "dev": true,
             "dependencies": {
                 "debug": "^3.2.7"
@@ -4497,12 +4542,12 @@
             "dev": true
         },
         "node_modules/espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             },
@@ -4527,9 +4572,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-            "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -4641,15 +4686,15 @@
             "dev": true
         },
         "node_modules/fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -4687,18 +4732,18 @@
             "dev": true
         },
         "node_modules/fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
         },
         "node_modules/fb-watchman": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
-            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
@@ -4826,9 +4871,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -4836,7 +4881,7 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -4911,13 +4956,14 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
             "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3"
             },
             "funding": {
@@ -5120,9 +5166,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/grapheme-splitter": {
@@ -5287,6 +5333,24 @@
                 "node": ">=10"
             }
         },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/hosted-git-info/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5294,30 +5358,29 @@
             "dev": true
         },
         "node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
             "dev": true,
             "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
             "dev": true,
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -5330,9 +5393,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -5537,9 +5600,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -5837,9 +5900,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-            "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.12.3",
@@ -6230,9 +6293,9 @@
             }
         },
         "node_modules/jest-pnp-resolver": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -6482,9 +6545,9 @@
             }
         },
         "node_modules/js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.1.tgz",
+            "integrity": "sha512-6Gsx8R0RucyePbWqPssR8DyfuXmLBooYN5cZFZKjHGnQuaf7pEzhtpceagJxVu4LqhYY5EYA7nko3FmeHZ1KbA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -6807,9 +6870,9 @@
             "dev": true
         },
         "node_modules/loglevel": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-            "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+            "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
@@ -6894,20 +6957,17 @@
             }
         },
         "node_modules/long": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-            "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/make-dir": {
@@ -6974,44 +7034,44 @@
             }
         },
         "node_modules/marked-terminal": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
-            "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
+            "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
             "dev": true,
             "dependencies": {
-                "ansi-escapes": "^5.0.0",
+                "ansi-escapes": "^6.2.0",
                 "cardinal": "^2.1.1",
-                "chalk": "^5.0.0",
-                "cli-table3": "^0.6.1",
+                "chalk": "^5.2.0",
+                "cli-table3": "^0.6.3",
                 "node-emoji": "^1.11.0",
-                "supports-hyperlinks": "^2.2.0"
+                "supports-hyperlinks": "^2.3.0"
             },
             "engines": {
                 "node": ">=14.13.1 || >=16.0.0"
             },
             "peerDependencies": {
-                "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+                "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
             }
         },
         "node_modules/marked-terminal/node_modules/ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+            "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
             "dev": true,
             "dependencies": {
-                "type-fest": "^1.0.2"
+                "type-fest": "^3.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/marked-terminal/node_modules/chalk": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
             "dev": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7021,12 +7081,12 @@
             }
         },
         "node_modules/marked-terminal/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
+            "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7140,10 +7200,13 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "dev": true
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/minimist-options": {
             "version": "4.1.0",
@@ -7220,9 +7283,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "dev": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -7246,9 +7309,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-            "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+            "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
             "dev": true
         },
         "node_modules/normalize-package-data": {
@@ -7288,9 +7351,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "9.6.5",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.5.tgz",
-            "integrity": "sha512-0SYs9lz1ND7V3+Lz6EbsnUdZ4OxjQOHbaIKdWd8OgsbZ2hCC2ZeiXMEaBEPEVBaILW+huFA0pJ1YME+52iZI5g==",
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-9.7.2.tgz",
+            "integrity": "sha512-LLoOudiSURxzRxfGj+vsD+hKKv2EfxyshDOznxruIkZMouvbaF5sFm4yAwHqxS8aVaOdRl03pRmGpcrFMqMt3g==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -7347,10 +7410,10 @@
                 "proc-log",
                 "qrcode-terminal",
                 "read",
-                "read-package-json",
-                "read-package-json-fast",
                 "semver",
+                "sigstore",
                 "ssri",
+                "supports-color",
                 "tar",
                 "text-table",
                 "tiny-relative-date",
@@ -7362,71 +7425,71 @@
             "dev": true,
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^6.2.8",
-                "@npmcli/config": "^6.1.6",
-                "@npmcli/map-workspaces": "^3.0.3",
-                "@npmcli/package-json": "^3.0.0",
-                "@npmcli/run-script": "^6.0.0",
+                "@npmcli/arborist": "^6.2.10",
+                "@npmcli/config": "^6.2.1",
+                "@npmcli/map-workspaces": "^3.0.4",
+                "@npmcli/package-json": "^3.1.1",
+                "@npmcli/run-script": "^6.0.2",
                 "abbrev": "^2.0.0",
                 "archy": "~1.0.0",
-                "cacache": "^17.0.5",
-                "chalk": "^4.1.2",
+                "cacache": "^17.1.3",
+                "chalk": "^5.2.0",
                 "ci-info": "^3.8.0",
                 "cli-columns": "^4.0.0",
                 "cli-table3": "^0.6.3",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.16",
-                "fs-minipass": "^3.0.1",
-                "glob": "^9.3.2",
+                "fs-minipass": "^3.0.2",
+                "glob": "^10.2.7",
                 "graceful-fs": "^4.2.11",
                 "hosted-git-info": "^6.1.1",
-                "ini": "^4.1.0",
+                "ini": "^4.1.1",
                 "init-package-json": "^5.0.0",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^3.0.0",
                 "libnpmaccess": "^7.0.2",
-                "libnpmdiff": "^5.0.16",
-                "libnpmexec": "^5.0.16",
-                "libnpmfund": "^4.0.16",
+                "libnpmdiff": "^5.0.18",
+                "libnpmexec": "^6.0.1",
+                "libnpmfund": "^4.0.18",
                 "libnpmhook": "^9.0.3",
-                "libnpmorg": "^5.0.3",
-                "libnpmpack": "^5.0.16",
-                "libnpmpublish": "^7.1.3",
+                "libnpmorg": "^5.0.4",
+                "libnpmpack": "^5.0.18",
+                "libnpmpublish": "^7.4.0",
                 "libnpmsearch": "^6.0.2",
                 "libnpmteam": "^5.0.3",
                 "libnpmversion": "^4.0.2",
-                "make-fetch-happen": "^11.1.0",
-                "minimatch": "^7.4.6",
-                "minipass": "^4.2.8",
+                "make-fetch-happen": "^11.1.1",
+                "minimatch": "^9.0.0",
+                "minipass": "^5.0.0",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.3.1",
-                "nopt": "^7.1.0",
-                "npm-audit-report": "^4.0.0",
+                "node-gyp": "^9.4.0",
+                "nopt": "^7.2.0",
+                "npm-audit-report": "^5.0.0",
                 "npm-install-checks": "^6.1.1",
                 "npm-package-arg": "^10.1.0",
                 "npm-pick-manifest": "^8.0.1",
                 "npm-profile": "^7.0.1",
-                "npm-registry-fetch": "^14.0.4",
+                "npm-registry-fetch": "^14.0.5",
                 "npm-user-validate": "^2.0.0",
                 "npmlog": "^7.0.1",
                 "p-map": "^4.0.0",
-                "pacote": "^15.1.1",
+                "pacote": "^15.2.0",
                 "parse-conflict-json": "^3.0.1",
                 "proc-log": "^3.0.0",
                 "qrcode-terminal": "^0.12.0",
                 "read": "^2.1.0",
-                "read-package-json": "^6.0.1",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.5.0",
-                "ssri": "^10.0.3",
-                "tar": "^6.1.13",
+                "semver": "^7.5.2",
+                "sigstore": "^1.6.0",
+                "ssri": "^10.0.4",
+                "supports-color": "^9.3.1",
+                "tar": "^6.1.15",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
                 "treeverse": "^3.0.0",
                 "validate-npm-package-name": "^5.0.0",
-                "which": "^3.0.0",
-                "write-file-atomic": "^5.0.0"
+                "which": "^3.0.1",
+                "write-file-atomic": "^5.0.1"
             },
             "bin": {
                 "npm": "bin/npm-cli.js",
@@ -7458,11 +7521,72 @@
                 "node": ">=0.1.90"
             }
         },
-        "node_modules/npm/node_modules/@gar/promisify": {
-            "version": "1.1.3",
+        "node_modules/npm/node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
         },
         "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
@@ -7471,7 +7595,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "6.2.8",
+            "version": "6.2.10",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7492,7 +7616,7 @@
                 "hosted-git-info": "^6.1.1",
                 "json-parse-even-better-errors": "^3.0.0",
                 "json-stringify-nice": "^1.1.4",
-                "minimatch": "^7.4.2",
+                "minimatch": "^9.0.0",
                 "nopt": "^7.0.0",
                 "npm-install-checks": "^6.0.0",
                 "npm-package-arg": "^10.1.0",
@@ -7518,12 +7642,13 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "6.1.6",
+            "version": "6.2.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/map-workspaces": "^3.0.2",
+                "ci-info": "^3.8.0",
                 "ini": "^4.1.0",
                 "nopt": "^7.0.0",
                 "proc-log": "^3.0.0",
@@ -7560,7 +7685,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "4.0.4",
+            "version": "4.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7595,14 +7720,14 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "3.0.3",
+            "version": "3.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^2.0.0",
-                "glob": "^9.3.1",
-                "minimatch": "^7.4.2",
+                "glob": "^10.2.2",
+                "minimatch": "^9.0.0",
                 "read-package-json-fast": "^3.0.0"
             },
             "engines": {
@@ -7624,19 +7749,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/npm/node_modules/@npmcli/move-file": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/npm/node_modules/@npmcli/name-from-folder": {
             "version": "2.0.0",
             "dev": true,
@@ -7656,12 +7768,17 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "3.0.0",
+            "version": "3.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0"
+                "@npmcli/git": "^4.1.0",
+                "glob": "^10.2.2",
+                "json-parse-even-better-errors": "^3.0.0",
+                "normalize-package-data": "^5.0.0",
+                "npm-normalize-package-bin": "^3.0.1",
+                "proc-log": "^3.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -7692,7 +7809,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "6.0.0",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7707,11 +7824,35 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/npm/node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
             "version": "0.1.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/tuf": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.1.0",
+                "make-fetch-happen": "^11.0.1",
+                "tuf-js": "^1.1.3"
+            },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -7735,13 +7876,13 @@
             }
         },
         "node_modules/npm/node_modules/@tufjs/models": {
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "@tufjs/canonical-json": "1.0.0",
-                "minimatch": "^7.4.6"
+                "minimatch": "^9.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -7949,21 +8090,20 @@
             }
         },
         "node_modules/npm/node_modules/cacache": {
-            "version": "17.0.5",
+            "version": "17.1.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^3.1.0",
                 "fs-minipass": "^3.0.0",
-                "glob": "^9.3.1",
+                "glob": "^10.2.2",
                 "lru-cache": "^7.7.1",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
                 "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
                 "ssri": "^10.0.0",
                 "tar": "^6.1.11",
                 "unique-filename": "^3.0.0"
@@ -7973,16 +8113,12 @@
             }
         },
         "node_modules/npm/node_modules/chalk": {
-            "version": "4.1.2",
+            "version": "5.2.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -8137,6 +8273,35 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/npm/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/npm/node_modules/cssesc": {
             "version": "3.0.0",
             "dev": true,
@@ -8208,6 +8373,12 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/npm/node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
         "node_modules/npm/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
@@ -8257,6 +8428,12 @@
                 "node": ">=0.8.x"
             }
         },
+        "node_modules/npm/node_modules/exponential-backoff": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/npm/node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "dev": true,
@@ -8266,13 +8443,29 @@
                 "node": ">= 4.9.1"
             }
         },
-        "node_modules/npm/node_modules/fs-minipass": {
-            "version": "3.0.1",
+        "node_modules/npm/node_modules/foreground-child": {
+            "version": "3.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^4.0.0"
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^5.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8291,7 +8484,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/gauge": {
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8300,7 +8493,7 @@
                 "color-support": "^1.1.3",
                 "console-control-strings": "^1.1.0",
                 "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.0.1",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1",
                 "wide-align": "^1.1.5"
@@ -8310,15 +8503,19 @@
             }
         },
         "node_modules/npm/node_modules/glob": {
-            "version": "9.3.2",
+            "version": "10.2.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "minimatch": "^7.4.1",
-                "minipass": "^4.2.4",
-                "path-scurry": "^1.6.1"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2",
+                "path-scurry": "^1.7.0"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -8343,15 +8540,6 @@
             },
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/npm/node_modules/has-flag": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/npm/node_modules/has-unicode": {
@@ -8448,12 +8636,12 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ignore-walk": {
-            "version": "6.0.2",
+            "version": "6.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minimatch": "^7.4.2"
+                "minimatch": "^9.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8477,12 +8665,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npm/node_modules/infer-owner": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
         "node_modules/npm/node_modules/inflight": {
             "version": "1.0.6",
             "dev": true,
@@ -8500,7 +8682,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ini": {
-            "version": "4.1.0",
+            "version": "4.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8554,7 +8736,7 @@
             }
         },
         "node_modules/npm/node_modules/is-core-module": {
-            "version": "2.11.0",
+            "version": "2.12.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8585,6 +8767,24 @@
             "dev": true,
             "inBundle": true,
             "license": "ISC"
+        },
+        "node_modules/npm/node_modules/jackspeak": {
+            "version": "2.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
         },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
             "version": "3.0.0",
@@ -8639,17 +8839,17 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "5.0.16",
+            "version": "5.0.18",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.8",
+                "@npmcli/arborist": "^6.2.10",
                 "@npmcli/disparity-colors": "^3.0.0",
                 "@npmcli/installed-package-contents": "^2.0.2",
                 "binary-extensions": "^2.2.0",
                 "diff": "^5.1.0",
-                "minimatch": "^7.4.2",
+                "minimatch": "^9.0.0",
                 "npm-package-arg": "^10.1.0",
                 "pacote": "^15.0.8",
                 "tar": "^6.1.13"
@@ -8659,14 +8859,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "5.0.16",
+            "version": "6.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.8",
+                "@npmcli/arborist": "^6.2.10",
                 "@npmcli/run-script": "^6.0.0",
-                "chalk": "^4.1.0",
                 "ci-info": "^3.7.1",
                 "npm-package-arg": "^10.1.0",
                 "npmlog": "^7.0.1",
@@ -8682,12 +8881,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "4.0.16",
+            "version": "4.0.18",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.8"
+                "@npmcli/arborist": "^6.2.10"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8707,7 +8906,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmorg": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8720,12 +8919,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "5.0.16",
+            "version": "5.0.18",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.8",
+                "@npmcli/arborist": "^6.2.10",
                 "@npmcli/run-script": "^6.0.0",
                 "npm-package-arg": "^10.1.0",
                 "pacote": "^15.0.8"
@@ -8735,7 +8934,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpublish": {
-            "version": "7.1.3",
+            "version": "7.4.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8746,7 +8945,7 @@
                 "npm-registry-fetch": "^14.0.3",
                 "proc-log": "^3.0.0",
                 "semver": "^7.3.7",
-                "sigstore": "^1.0.0",
+                "sigstore": "^1.4.0",
                 "ssri": "^10.0.1"
             },
             "engines": {
@@ -8804,7 +9003,7 @@
             }
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "11.1.0",
+            "version": "11.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8816,7 +9015,7 @@
                 "https-proxy-agent": "^5.0.0",
                 "is-lambda": "^1.0.1",
                 "lru-cache": "^7.7.1",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-fetch": "^3.0.0",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
@@ -8830,7 +9029,7 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "7.4.6",
+            "version": "9.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8838,14 +9037,14 @@
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm/node_modules/minipass": {
-            "version": "4.2.8",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8878,12 +9077,12 @@
             }
         },
         "node_modules/npm/node_modules/minipass-fetch": {
-            "version": "3.0.2",
+            "version": "3.0.3",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-sized": "^1.0.3",
                 "minizlib": "^2.1.2"
             },
@@ -9050,15 +9249,16 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "9.3.1",
+            "version": "9.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
                 "glob": "^7.1.4",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^10.0.3",
+                "make-fetch-happen": "^11.0.3",
                 "nopt": "^6.0.0",
                 "npmlog": "^6.0.0",
                 "rimraf": "^3.0.2",
@@ -9071,19 +9271,6 @@
             },
             "engines": {
                 "node": "^12.13 || ^14.13 || >=16"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promisify": "^1.1.3",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
@@ -9113,87 +9300,6 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-            "version": "16.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
-            "version": "8.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
-            "version": "5.1.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
@@ -9235,33 +9341,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-            "version": "10.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^16.1.0",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^2.0.3",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^9.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
             "version": "3.1.2",
             "dev": true,
@@ -9272,35 +9351,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.1.6",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -9347,41 +9397,11 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-            "version": "9.0.1",
+        "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+            "version": "3.0.7",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.1.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
+            "license": "ISC"
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/which": {
             "version": "2.0.2",
@@ -9399,7 +9419,7 @@
             }
         },
         "node_modules/npm/node_modules/nopt": {
-            "version": "7.1.0",
+            "version": "7.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9429,13 +9449,10 @@
             }
         },
         "node_modules/npm/node_modules/npm-audit-report": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "chalk": "^4.0.0"
-            },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -9465,7 +9482,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-normalize-package-bin": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9529,13 +9546,13 @@
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "14.0.4",
+            "version": "14.0.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^11.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-fetch": "^3.0.0",
                 "minipass-json-stream": "^1.0.1",
                 "minizlib": "^2.1.2",
@@ -9595,7 +9612,7 @@
             }
         },
         "node_modules/npm/node_modules/pacote": {
-            "version": "15.1.1",
+            "version": "15.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9606,7 +9623,7 @@
                 "@npmcli/run-script": "^6.0.0",
                 "cacache": "^17.0.0",
                 "fs-minipass": "^3.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "npm-package-arg": "^10.0.0",
                 "npm-packlist": "^7.0.0",
                 "npm-pick-manifest": "^8.0.0",
@@ -9615,7 +9632,7 @@
                 "promise-retry": "^2.0.1",
                 "read-package-json": "^6.0.0",
                 "read-package-json-fast": "^3.0.0",
-                "sigstore": "^1.0.0",
+                "sigstore": "^1.3.0",
                 "ssri": "^10.0.0",
                 "tar": "^6.1.11"
             },
@@ -9649,14 +9666,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/npm/node_modules/path-key": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/npm/node_modules/path-scurry": {
-            "version": "1.6.3",
+            "version": "1.9.2",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^7.14.1",
-                "minipass": "^4.0.2"
+                "lru-cache": "^9.1.1",
+                "minipass": "^5.0.0 || ^6.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -9665,8 +9691,17 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "9.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
         "node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "6.0.11",
+            "version": "6.0.13",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9775,12 +9810,12 @@
             }
         },
         "node_modules/npm/node_modules/read-package-json": {
-            "version": "6.0.1",
+            "version": "6.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "glob": "^9.3.0",
+                "glob": "^10.2.2",
                 "json-parse-even-better-errors": "^3.0.0",
                 "normalize-package-data": "^5.0.0",
                 "npm-normalize-package-bin": "^3.0.0"
@@ -9803,7 +9838,7 @@
             }
         },
         "node_modules/npm/node_modules/readable-stream": {
-            "version": "4.3.0",
+            "version": "4.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9884,8 +9919,22 @@
             }
         },
         "node_modules/npm/node_modules/safe-buffer": {
-            "version": "5.1.2",
+            "version": "5.2.1",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "inBundle": true,
             "license": "MIT"
         },
@@ -9897,7 +9946,7 @@
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
-            "version": "7.5.0",
+            "version": "7.5.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9929,19 +9978,47 @@
             "inBundle": true,
             "license": "ISC"
         },
-        "node_modules/npm/node_modules/signal-exit": {
-            "version": "3.0.7",
+        "node_modules/npm/node_modules/shebang-command": {
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/npm/node_modules/sigstore": {
-            "version": "1.3.0",
+            "version": "1.6.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.1.0",
+                "@sigstore/tuf": "^1.0.0",
                 "make-fetch-happen": "^11.0.1",
                 "tuf-js": "^1.1.3"
             },
@@ -10023,27 +10100,42 @@
             "license": "CC0-1.0"
         },
         "node_modules/npm/node_modules/ssri": {
-            "version": "10.0.3",
+            "version": "10.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^4.0.0"
+                "minipass": "^5.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/string_decoder": {
-            "version": "1.1.1",
+            "version": "1.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/npm/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/string-width-cjs": {
+            "name": "string-width",
             "version": "4.2.3",
             "dev": true,
             "inBundle": true,
@@ -10069,27 +10161,40 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npm/node_modules/supports-color": {
-            "version": "7.2.0",
+        "node_modules/npm/node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "has-flag": "^4.0.0"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
             }
         },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "9.3.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/npm/node_modules/tar": {
-            "version": "6.1.13",
+            "version": "6.1.15",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
@@ -10144,13 +10249,14 @@
             }
         },
         "node_modules/npm/node_modules/tuf-js": {
-            "version": "1.1.4",
+            "version": "1.1.7",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "@tufjs/models": "1.0.3",
-                "make-fetch-happen": "^11.0.1"
+                "@tufjs/models": "1.0.4",
+                "debug": "^4.3.4",
+                "make-fetch-happen": "^11.1.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -10224,7 +10330,7 @@
             }
         },
         "node_modules/npm/node_modules/which": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10247,6 +10353,103 @@
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
+        "node_modules/npm/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
             "dev": true,
@@ -10254,13 +10457,13 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
+                "signal-exit": "^4.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -10359,17 +10562,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -10452,19 +10655,6 @@
             "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
             "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/retry": "0.12.0",
-                "retry": "^0.13.1"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -10578,9 +10768,9 @@
             }
         },
         "node_modules/pirates": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
-            "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+            "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -10926,9 +11116,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -11133,9 +11323,9 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -11235,12 +11425,12 @@
             "dev": true
         },
         "node_modules/resolve": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.9.0",
+                "is-core-module": "^2.11.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -11285,21 +11475,12 @@
             }
         },
         "node_modules/resolve.exports": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-            "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
+            "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/retry": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/reusify": {
@@ -11749,9 +11930,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-            "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -11789,6 +11970,24 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/semver/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semver/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -11969,9 +12168,9 @@
             "dev": true
         },
         "node_modules/spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
@@ -11995,9 +12194,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+            "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
             "dev": true
         },
         "node_modules/split": {
@@ -12022,9 +12221,9 @@
             }
         },
         "node_modules/split2/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -12042,9 +12241,9 @@
             "dev": true
         },
         "node_modules/stack-utils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-            "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "dev": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
@@ -12220,9 +12419,9 @@
             }
         },
         "node_modules/supports-hyperlinks": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-            "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+            "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
             "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0",
@@ -12356,9 +12555,9 @@
             }
         },
         "node_modules/through2/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -12403,10 +12602,13 @@
             "dev": true
         },
         "node_modules/traverse": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-            "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
-            "dev": true
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+            "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -12681,13 +12883,13 @@
             }
         },
         "node_modules/tsconfig-paths": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-            "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+            "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
             "dev": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
+                "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
@@ -12732,9 +12934,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
             "peer": true
         },
         "node_modules/tsutils": {
@@ -12877,9 +13079,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-            "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
             "dev": true,
             "funding": [
                 {
@@ -12889,6 +13091,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
@@ -12896,7 +13102,7 @@
                 "picocolors": "^1.0.0"
             },
             "bin": {
-                "browserslist-lint": "cli.js"
+                "update-browserslist-db": "cli.js"
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
@@ -12939,9 +13145,9 @@
             "dev": true
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
-            "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+            "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
@@ -12987,9 +13193,9 @@
             }
         },
         "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -12997,6 +13203,9 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/vue-eslint-parser/node_modules/estraverse": {
@@ -13084,15 +13293,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -13160,24 +13360,24 @@
             }
         },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "node_modules/yargs": {
-            "version": "17.5.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-            "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "dependencies": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
                 "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
                 "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "author": "Luca Becker <luca.becker@sunbury.xyz> (https://sunbury.xyz/)",
     "license": "GPL-3.0",
     "dependencies": {
+        "@richardhopton/noise-c.wasm": "0.5.0",
         "color-convert": "2.0.1",
         "protobufjs": "7.2.3"
     },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,21 +1,14 @@
 import {
     ConnectRequest,
     ConnectResponse,
-    DeviceInfoRequest,
     DeviceInfoResponse,
     HelloRequest,
     HelloResponse,
-    ListEntitiesRequest,
-    PingRequest,
     PingResponse,
-    SubscribeStatesRequest,
 } from './protobuf/api';
 import { ReadData } from './connection';
 import { Observable, of, Subscription } from 'rxjs';
-import { MessageTypes } from './requestResponseMatching';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
 import { Reader } from 'protobufjs/minimal';
-import { EspSocket } from './espSocket';
 import { voidMessage } from './protobuf/api_options';
 
 export interface Decoder<T> {
@@ -26,77 +19,12 @@ export const decode = <T>(decoder: Decoder<T>, data: ReadData): T => {
     return decoder.decode(new Reader(data.payload));
 };
 
-export class Client {
-    private readonly subscription: Subscription;
-
-    constructor(private readonly socket: EspSocket) {
-        this.subscription = new Subscription();
-        this.subscription.add(
-            this.socket.espData$
-                .pipe(
-                    tap((data) => {
-                        if (data.type === MessageTypes.PingRequest) {
-                            this.socket.sendEspMessage(MessageTypes.PingResponse, PingResponse.encode({}).finish());
-                        }
-                    }),
-                )
-                .subscribe(),
-        );
-    }
-
-    public terminate(): void {
-        this.subscription.unsubscribe();
-    }
-
-    hello(request: HelloRequest): Observable<HelloResponse> {
-        const data = HelloRequest.encode(request).finish();
-        this.socket.sendEspMessage(MessageTypes.HelloRequest, data);
-        return this.socket.espData$.pipe(
-            filter((value: ReadData) => value.type === MessageTypes.HelloResponse),
-            take(1),
-            switchMap((data: ReadData) => of(HelloResponse.decode(new Reader(data.payload)))),
-        );
-    }
-
-    connect(request: ConnectRequest): Observable<ConnectResponse> {
-        const data = ConnectRequest.encode(request).finish();
-        this.socket.sendEspMessage(MessageTypes.ConnectRequest, data);
-        return this.socket.espData$.pipe(
-            filter((value: ReadData) => value.type === MessageTypes.ConnectResponse),
-            take(1),
-            switchMap((data: ReadData) => of(ConnectResponse.decode(new Reader(data.payload)))),
-        );
-    }
-
-    ping(): Observable<PingResponse> {
-        const data = PingRequest.encode({}).finish();
-        this.socket.sendEspMessage(MessageTypes.ConnectRequest, data);
-        return this.socket.espData$.pipe(
-            filter((value: ReadData) => value.type === MessageTypes.PingResponse),
-            take(1),
-            switchMap((data: ReadData) => of(PingResponse.decode(new Reader(data.payload)))),
-        );
-    }
-
-    deviceInfo(): Observable<DeviceInfoResponse> {
-        const data = DeviceInfoRequest.encode({}).finish();
-        this.socket.sendEspMessage(MessageTypes.DeviceInfoRequest, data);
-        return this.socket.espData$.pipe(
-            filter(({ type }: ReadData) => type === MessageTypes.DeviceInfoResponse),
-            take(1),
-            switchMap(({ payload }: ReadData) => of(DeviceInfoResponse.decode(new Reader(payload)))),
-        );
-    }
-
-    listEntities(): Observable<voidMessage> {
-        const data = ListEntitiesRequest.encode({}).finish();
-        this.socket.sendEspMessage(MessageTypes.ListEntitiesRequest, data);
-        return of(voidMessage.decode(new Reader(new Uint8Array())));
-    }
-
-    subscribeStateChange(): Observable<voidMessage> {
-        const data = SubscribeStatesRequest.encode({}).finish();
-        this.socket.sendEspMessage(MessageTypes.SubscribeStatesRequest, data);
-        return of(voidMessage.decode(new Reader(new Uint8Array())));
-    }
+export interface Client{
+    terminate(): void;
+    hello(request: HelloRequest): Observable<HelloResponse>;
+    connect(request: ConnectRequest): Observable<ConnectResponse>;
+    ping(): Observable<PingResponse>;
+    deviceInfo(): Observable<DeviceInfoResponse>;
+    subscribeStateChange(): Observable<voidMessage>;
+    listEntities(): Observable<voidMessage>;
 }

--- a/src/api/espSocket.ts
+++ b/src/api/espSocket.ts
@@ -1,5 +1,5 @@
 import { from, Observable } from 'rxjs';
-import { filter, map, switchMap, take, takeUntil, timeout } from 'rxjs/operators';
+import { filter, map, switchMap, take, takeUntil, timeout, tap } from 'rxjs/operators';
 import { CommandInterface } from '../components/commandInterface';
 import { RxjsSocket, RxjsSocketConfiguration } from './socket';
 import { BytePositions, HEADER_FIRST_BYTE, HEADER_SIZE } from './bytePositions';
@@ -14,33 +14,93 @@ export interface ReadData {
 export class EspSocket extends RxjsSocket implements CommandInterface {
     public readonly espData$: Observable<ReadData>;
 
-    constructor(host: string, port: number, config?: RxjsSocketConfiguration) {
-        super(host, port, config);
+    
+    extractFrameBytes(buffer: Buffer) {
+        if (buffer.length < 3) return null;
+        const indicator = buffer[0];
+        if (indicator != 1)
+            throw new Error("Bad format. Expected 1 at the begin");
 
-        this.espData$ = this.data$.pipe(
-            switchMap((buffer: Buffer) => {
-                let bytesTaken = 0;
-                const result: Buffer[] = [];
-                while (bytesTaken < buffer.length) {
-                    const subBuffer = buffer.slice(
-                        bytesTaken,
-                        bytesTaken + HEADER_SIZE + buffer[bytesTaken + BytePositions.LENGTH],
-                    );
-                    result.push(subBuffer);
-                    bytesTaken += HEADER_SIZE + buffer[bytesTaken + BytePositions.LENGTH];
-                }
-                return from(result);
-            }),
-            filter((buffer: Buffer) => buffer.length >= HEADER_SIZE),
-            filter((buffer: Buffer) => buffer.readUInt8(BytePositions.ZERO) === HEADER_FIRST_BYTE),
-            map((buffer: Buffer) => ({
-                type: buffer.readUInt8(BytePositions.TYPE),
-                payload: buffer.slice(
-                    BytePositions.PAYLOAD,
-                    BytePositions.PAYLOAD + buffer.readUInt8(BytePositions.LENGTH),
-                ),
-            })),
-        );
+        const frameEnd = 3 + ((buffer[1] << 8) | buffer[2]);
+        if (buffer.length < frameEnd) return [] as unknown as Buffer;
+        const frame = buffer.subarray(3, frameEnd);
+        buffer = buffer.subarray(frameEnd);
+        return frame;
+    }
+
+    constructor(host: string, port: number, config?: RxjsSocketConfiguration, encryption?: boolean) {
+        super(host, port, config);
+        
+        if(encryption){
+
+            this.espData$ = this.data$.pipe(
+                // // filter((buffer: Buffer) => buffer == null),
+                // tap((buffer:Buffer) => console.log(`espNoiseData$: ${buffer}`)),
+                // tap((buffer:Buffer) => console.log(`espNoiseData$ readUInt8(0): ${buffer.readUInt8(0)}`)),
+                // tap((buffer:Buffer) => console.log(`espNoiseData$ readUInt8(1): ${buffer.readUInt8(1)}`)),
+                // tap((buffer:Buffer) => console.log(`espNoiseData$ readUInt8(2): ${buffer.readUInt8(BytePositions.TYPE)}`)),
+                // tap((buffer:Buffer) => console.log(`espNoiseData$ readUInt8(3): ${buffer.readUInt8(3)}`)),
+                filter((buffer: Buffer) => buffer.length >= HEADER_SIZE),
+                filter((buffer: Buffer) => buffer.readUInt8(BytePositions.ZERO) === 1),
+                tap((buffer: Buffer) =>{
+                    console.log(`espData$ ${buffer.readUInt8(BytePositions.TYPE)}, ${buffer.slice(
+                        BytePositions.PAYLOAD,
+                        BytePositions.PAYLOAD + buffer.readUInt8(BytePositions.LENGTH)).toString()}`)
+                }),
+                map((buffer: Buffer) => {
+                    var frame = this.extractFrameBytes(buffer);
+
+                    if (frame == null || frame.length == 0){
+                        return ({
+                            type: 0,
+                            payload: new Uint8Array()
+                        } as ReadData);
+                    }
+
+                    return ({
+                        type: frame[0],
+                        payload: frame.subarray(1)
+                    } as ReadData)
+            }));
+        }else{
+
+            this.espData$ = this.data$.pipe(
+                switchMap((buffer: Buffer) => {
+
+                    let bytesTaken = 0;
+                    const result: Buffer[] = [];
+
+                    while (bytesTaken < buffer.length) {
+                        const subBuffer = buffer.slice(
+                            bytesTaken,
+                            bytesTaken + HEADER_SIZE + buffer[bytesTaken + BytePositions.LENGTH],
+                        );
+                        result.push(subBuffer);
+                        bytesTaken += HEADER_SIZE + buffer[bytesTaken + BytePositions.LENGTH];
+                    }
+                    return from(result);
+                }),
+                // tap((buffer: Buffer) =>{
+                //     console.log(`espData$ ${buffer}`)}),
+                // // tap((buffer:Buffer) => console.log(`${buffer[0]}: ${buffer.subarray(1).toString()}`)),
+                // // tap((buffer: Buffer) => console.log(`${buffer.length}, ${HEADER_SIZE}`)),
+                // // tap((buffer: Buffer) => console.log(`${buffer.readUInt8(BytePositions.ZERO)}, ${HEADER_FIRST_BYTE}`)),
+                // tap((buffer: Buffer) =>{
+                //     console.log(`espData$ ${buffer.readUInt8(BytePositions.TYPE)}, ${buffer.slice(
+                //         BytePositions.PAYLOAD,
+                //         BytePositions.PAYLOAD + buffer.readUInt8(BytePositions.LENGTH)).toString()}`)
+                // }),
+                filter((buffer: Buffer) => buffer.length >= HEADER_SIZE),
+                filter((buffer: Buffer) => buffer.readUInt8(BytePositions.ZERO) === HEADER_FIRST_BYTE),
+                map((buffer: Buffer) => ({
+                    type: buffer.readUInt8(BytePositions.TYPE),
+                    payload: buffer.slice(
+                        BytePositions.PAYLOAD,
+                        BytePositions.PAYLOAD + buffer.readUInt8(BytePositions.LENGTH),
+                    ),
+                })),
+            );
+        }
     }
 
     sendEspMessage(type: MessageTypes, payload: Uint8Array): void {
@@ -50,8 +110,23 @@ export class EspSocket extends RxjsSocket implements CommandInterface {
                 filter(isTrue),
                 take(1),
                 switchMap(() => {
+                    console.log('sendespmessage: ',MessageTypes[type]);
                     const final = new Uint8Array([HEADER_FIRST_BYTE, payload.length, type, ...payload]);
                     return this.send(final);
+                }),
+                takeUntil(this.terminate),
+            )
+            .subscribe();
+    }
+
+    sendEspMessageEncrypted(type: MessageTypes, frame: Uint8Array): void{
+        this.connected$
+            .pipe(
+                timeout(5000),
+                filter(isTrue),
+                take(1),
+                switchMap(() => {
+                    return this.send(frame);
                 }),
                 takeUntil(this.terminate),
             )

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,7 @@
 export * from './bytePositions';
 export * from './client';
+export * from './plaintextClient';
+export * from './noiseClient';
 export * from './connection';
 export * from './espDevice';
 export * from './helpers';

--- a/src/api/noiseClient.ts
+++ b/src/api/noiseClient.ts
@@ -1,0 +1,219 @@
+import {
+    ConnectRequest,
+    ConnectResponse,
+    DeviceInfoRequest,
+    DeviceInfoResponse,
+    HelloRequest,
+    HelloResponse,
+    ListEntitiesRequest,
+    PingRequest,
+    PingResponse,
+    SubscribeStatesRequest,
+} from './protobuf/api';
+import { Client } from './client';
+import { ReadData } from './connection';
+import { Observable, of, Subscription } from 'rxjs';
+import { MessageTypes } from './requestResponseMatching';
+import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { Message, Reader } from 'protobufjs/minimal';
+import { EspSocket } from './espSocket';
+import { voidMessage } from './protobuf/api_options';
+import { error } from 'console';
+
+// import Noise from 'noise-handshake';
+// import Cipher from 'noise-handshake/cipher';
+var createNoise = require("@richardhopton/noise-c.wasm");
+
+
+
+// enum NoiseConnectionState{
+//     HELLO = 1,
+//     HANDSHAKE = 2,
+//     READY = 3,
+//     CLOSED = 4,
+// }
+
+
+export class NoiseClient implements Client {
+    private readonly subscription: Subscription;
+    private client: {
+        Initialize: (arg0: Uint8Array, arg1: null, arg2: null, arg3: Uint8Array) => void;
+        WriteMessage: () => any;
+        ReadMessage: (arg0: Buffer, arg1: boolean) => void;
+        Split: () => [any, any];
+    };
+    private encryptor: { 
+        EncryptWithAd: (arg0: never[], arg1: any) => Uint8Array; 
+    }  | undefined;
+    private  decryptor: { 
+        DecryptWithAd: (arg0: never[], arg1: Buffer | null) => void; 
+    } | undefined;
+    
+    // private state: NoiseConnectionState = NoiseConnectionState.HELLO;
+
+    constructor(private readonly socket: EspSocket, 
+        private readonly encryptionKey: string) {
+        console.log("~~~noiseClient.constructor~~~");
+        this.subscription = new Subscription();
+        // this.state = NoiseConnectionState.HELLO;
+        this.subscription.add(
+            this.socket.espData$
+                .pipe(
+                    tap((data) => {
+                        if (data.type === MessageTypes.PingRequest) {
+                            this.socket.sendEspMessageEncrypted(MessageTypes.PingResponse, PingResponse.encode({}).finish());
+                        }
+                    }),
+                )
+                .subscribe(),
+        );
+
+        // setup noise client
+        const psk = Buffer.from(encryptionKey, "base64");
+        this.client = {} as any;
+        new Promise((res) => createNoise(res))
+        .then(result => {
+            var noise = result as any;
+            this.client = noise.HandshakeState(
+                "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+                noise.constants.NOISE_ROLE_INITIATOR
+            );
+                
+            this.client.Initialize(
+                new Uint8Array(Buffer.from("NoiseAPIInit\x00\x00")),    // prologue
+                null,                                                   // s
+                null,                                                   // rs
+                new Uint8Array(psk)                                     // psk
+            );
+        });
+
+           
+    }
+
+    public terminate(): void {
+        this.subscription.unsubscribe();
+    }
+
+    hello(request: HelloRequest): Observable<HelloResponse> {
+        const frame = new Uint8Array();
+        const payload = this.writeHandshakePacket(new Uint8Array());
+
+        this.socket.sendEspMessageEncrypted(MessageTypes.HelloRequest, payload);
+
+        return this.socket.espData$.pipe(
+            // filter((value: ReadData) => value.type === MessageTypes.HelloResponse),
+            take(1),
+            tap((data: ReadData) => console.log(`some error (${data.type}): ${data.payload.toString()}`)),
+            switchMap((data: ReadData) => of({ serverInfo: data.payload.toString() } as HelloResponse)),
+        );
+    }
+
+    connect(request: ConnectRequest): Observable<ConnectResponse> {
+        console.log("~~~noiseClient.connect~~~");
+        const payload = this.writeHandshakePacket( Buffer.from(["\x00",...this.client.WriteMessage()]));
+
+        this.socket.sendEspMessageEncrypted(MessageTypes.ConnectRequest, payload);
+
+            
+        return this.socket.espData$.pipe(
+            // filter((value: ReadData) => value.type === MessageTypes.HelloResponse),
+            take(1),
+            switchMap((data: ReadData) => {
+                var invalidPassword = true;
+
+                this.client.ReadMessage(Buffer.from(data.payload), true);
+                var tempEncryptor: { EncryptWithAd: (arg0: never[], arg1: any) => Uint8Array; }
+                var tempDecryptor;
+        
+                [tempEncryptor, tempDecryptor] = this.client.Split();
+                if(tempEncryptor != null){
+                    invalidPassword = false;
+                    this.encryptor = tempEncryptor;
+                }
+                if(tempEncryptor != null){
+                    this.decryptor = tempDecryptor;
+                }
+
+                return of({ invalidPassword } as ConnectResponse);
+            }),
+        );
+    }
+
+    ping(): Observable<PingResponse> {
+        console.log("~~~noiseClient.ping()~~~");
+        const data = PingRequest.encode({}).finish();
+        this.socket.sendEspMessageEncrypted(MessageTypes.ConnectRequest, data);
+        return this.socket.espData$.pipe(
+            filter((value: ReadData) => value.type === MessageTypes.PingResponse),
+            take(1),
+            switchMap((data: ReadData) => of(PingResponse.decode(new Reader(data.payload)))),
+        );
+    }
+
+    deviceInfo(): Observable<DeviceInfoResponse> {
+        console.log("~~~noiseClient.deviceInfo()~~~");
+        const data = DeviceInfoRequest.encode({}).finish();
+        this.sendMessage(MessageTypes.DeviceInfoRequest, data);
+
+        return this.socket.espData$.pipe(
+            filter(({ type }: ReadData) => type === MessageTypes.DeviceInfoResponse),
+            tap((data: ReadData) => console.log(`deviceInfo: ${data.payload}`)),
+            take(1),
+            switchMap(({ payload }: ReadData) => of(DeviceInfoResponse.decode(new Reader(payload)))),
+        );
+    }
+
+    listEntities(): Observable<voidMessage> {
+        console.log("~~~noiseClient.listEntities~~~");
+
+        const data = ListEntitiesRequest.encode({}).finish();
+        this.sendMessage(MessageTypes.ListEntitiesRequest, data);
+        return of(voidMessage.decode(new Reader(new Uint8Array())));
+    }
+
+    subscribeStateChange(): Observable<voidMessage> {
+        console.log("~~~noiseClient.subscribeStateChange~~~");
+        const data = SubscribeStatesRequest.encode({}).finish();
+        this.sendMessage(MessageTypes.SubscribeStatesRequest, data);
+        return of(voidMessage.decode(new Reader(new Uint8Array())));
+        
+    }
+    
+    sendMessage(requestType: MessageTypes, encodedMessage: Uint8Array){
+        // get packet frame
+        const packet = this.writePacket(requestType, encodedMessage);  
+        
+        // encrypt
+        if(this.encryptor == undefined){
+            throw new Error("We have not established a connection with the server, encryptionKey needs to be set correctly");
+        }
+        const encryptedMessage = this.encryptor.EncryptWithAd([], packet);
+        console.info(`sendMessage, (${requestType}), (${encodedMessage}), (${packet}), (${encryptedMessage})`);
+        //send
+        this.socket.sendEspMessageEncrypted(MessageTypes.DeviceInfoRequest, encryptedMessage);
+    }
+    writePacket(requestType: MessageTypes, frame: Uint8Array) {
+        const frameLength = frame.length;
+        const header = [(requestType >> 8) & 0xFF, 
+                        requestType & 0xFF, 
+                        (frameLength >> 8) & 0xFF, 
+                        frameLength & 0xFF];
+        var payload: Uint8Array;
+        if(frameLength == 0){
+            return Uint8Array.from(header);
+        }else{
+            payload = Buffer.from([...header, ...frame]);
+        }
+
+        return payload;
+    }
+    
+    writeHandshakePacket(frame: Uint8Array){
+        const frameLength = frame.length;
+        const header = [0x01, (frameLength >> 8) & 0xFF, frameLength & 0xFF];
+        const payload = Buffer.from([...header, ...frame]);
+        return payload;
+    }
+    
+}
+

--- a/src/api/plaintextClient.ts
+++ b/src/api/plaintextClient.ts
@@ -1,0 +1,97 @@
+import {
+    ConnectRequest,
+    ConnectResponse,
+    DeviceInfoRequest,
+    DeviceInfoResponse,
+    HelloRequest,
+    HelloResponse,
+    ListEntitiesRequest,
+    PingRequest,
+    PingResponse,
+    SubscribeStatesRequest,
+} from './protobuf/api';
+import { Client } from './client';
+import { ReadData } from './connection';
+import { Observable, of, Subscription } from 'rxjs';
+import { MessageTypes } from './requestResponseMatching';
+import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { Reader } from 'protobufjs/minimal';
+import { EspSocket } from './espSocket';
+import { voidMessage } from './protobuf/api_options';
+
+
+export class PlaintextClient implements Client {
+    private readonly subscription: Subscription;
+
+    constructor(private readonly socket: EspSocket) {
+        this.subscription = new Subscription();
+        this.subscription.add(
+            this.socket.espData$
+                .pipe(
+                    tap((data) => {
+                        if (data.type === MessageTypes.PingRequest) {
+                            this.socket.sendEspMessage(MessageTypes.PingResponse, PingResponse.encode({}).finish());
+                        }
+                    }),
+                )
+                .subscribe(),
+        );
+    }
+
+    public terminate(): void {
+        this.subscription.unsubscribe();
+    }
+
+    hello(request: HelloRequest): Observable<HelloResponse> {
+        const data = HelloRequest.encode(request).finish();
+        this.socket.sendEspMessage(MessageTypes.HelloRequest, data);
+        return this.socket.espData$.pipe(
+            filter((value: ReadData) => value.type === MessageTypes.HelloResponse),
+            take(1),
+            switchMap((data: ReadData) => of(HelloResponse.decode(new Reader(data.payload)))),
+        );
+    }
+
+    connect(request: ConnectRequest): Observable<ConnectResponse> {
+        const data = ConnectRequest.encode(request).finish();
+        this.socket.sendEspMessage(MessageTypes.ConnectRequest, data);
+        return this.socket.espData$.pipe(
+            filter((value: ReadData) => value.type === MessageTypes.ConnectResponse),
+            take(1),
+            switchMap((data: ReadData) => of(ConnectResponse.decode(new Reader(data.payload)))),
+        );
+    }
+
+    ping(): Observable<PingResponse> {
+        const data = PingRequest.encode({}).finish();
+        this.socket.sendEspMessage(MessageTypes.ConnectRequest, data);
+        return this.socket.espData$.pipe(
+            filter((value: ReadData) => value.type === MessageTypes.PingResponse),
+            take(1),
+            switchMap((data: ReadData) => of(PingResponse.decode(new Reader(data.payload)))),
+        );
+    }
+
+    deviceInfo(): Observable<DeviceInfoResponse> {
+        const data = DeviceInfoRequest.encode({}).finish();
+        this.socket.sendEspMessage(MessageTypes.DeviceInfoRequest, data);
+        return this.socket.espData$.pipe(
+            filter(({ type }: ReadData) => type === MessageTypes.DeviceInfoResponse),
+            take(1),
+            switchMap(({ payload }: ReadData) => of(DeviceInfoResponse.decode(new Reader(payload)))),
+        );
+    }
+
+    listEntities(): Observable<voidMessage> {
+        console.log("listEntities");
+        const data = ListEntitiesRequest.encode({}).finish();
+        this.socket.sendEspMessage(MessageTypes.ListEntitiesRequest, data);
+        return of(voidMessage.decode(new Reader(new Uint8Array())));
+    }
+
+    subscribeStateChange(): Observable<voidMessage> {
+        const data = SubscribeStatesRequest.encode({}).finish();
+        this.socket.sendEspMessage(MessageTypes.SubscribeStatesRequest, data);
+        return of(voidMessage.decode(new Reader(new Uint8Array())));
+    }
+}

--- a/test/api/espDevice.spec.ts
+++ b/test/api/espDevice.spec.ts
@@ -34,7 +34,7 @@ describe('espDevice', () => {
     it(
         'connects',
         (done) => {
-            device = new EspDevice('localhost', '', portNumber);
+            device = new EspDevice('localhost', '', '', portNumber);
             device.discovery$
                 .pipe(
                     filter(isTrue),
@@ -55,7 +55,7 @@ describe('espDevice', () => {
                 data: ListEntitiesSwitchResponse.encode(listEntitySwitch).finish(),
             },
         ];
-        device = new EspDevice('localhost', '', portNumber);
+        device = new EspDevice('localhost', '', '', portNumber);
         device.discovery$
             .pipe(
                 filter(isTrue),
@@ -69,7 +69,7 @@ describe('espDevice', () => {
     });
 
     it('alive$ returns false on close', (done) => {
-        device = new EspDevice('localhost', '', portNumber);
+        device = new EspDevice('localhost', '', '', portNumber);
         device.discovery$
             .pipe(
                 filter(isTrue),
@@ -90,7 +90,7 @@ describe('espDevice', () => {
     xit(
         'alive$ runs out after 90s',
         (done) => {
-            device = new EspDevice('localhost', '', portNumber);
+            device = new EspDevice('localhost', '', '', portNumber);
             device.discovery$
                 .pipe(
                     filter(isTrue),
@@ -110,7 +110,7 @@ describe('espDevice', () => {
     it(
         'should not crash on a non existent esphome device abc',
         (done) => {
-            device = new EspDevice('localhost', '', 33333);
+            device = new EspDevice('localhost', '', '', 33333);
             device.discovery$
                 .pipe(
                     filter(isTrue),
@@ -134,7 +134,7 @@ describe('espDevice', () => {
 
     it('retries when it is told to', (done: DoneCallback) => {
         const retryWhen$ = new Subject<void>();
-        device = new EspDevice('localhost', '', portNumber);
+        device = new EspDevice('localhost', '', portNumber.toString());
 
         device.provideRetryObservable(retryWhen$);
         device.alive$


### PR DESCRIPTION
Initial draft implementation of adding NoiseClient (Encryption) to the esphome-ts library.

This got all the way through the handshake, but then any subsequent messages would never get accepted by the server.

Unfortunately I ran into a few stumbling blocks with the actual implementation of `esphome-ts` mainly due to the inconsistent nature of how `parseListResponse` would frequently drop entities (or not all entities would be received) before ListEntitiesDoneResponse was received. Once ListEntitiesDoneResponse was acknowledged no further entities would be added to the list, and therefore were never able to be added to HomeBridge.
Due to this I instead switched out this implementation of the Esphome Native API [esphome-native-api](https://github.com/twocolors/esphome-native-api/) which already had encryption, and far more Entities implemented.